### PR TITLE
Move yaml files inside of the tar to a root of the tar

### DIFF
--- a/assembly/build.sh
+++ b/assembly/build.sh
@@ -13,6 +13,8 @@ if [ ! -f ../ui/che_ui_service_plugin.theia ]; then
 fi
 
 tar cvf che-service-plugin.tar -C ../ui che_ui_service_plugin.theia
-tar uvf che-service-plugin.tar etc
+cd etc
+tar uvf ../che-service-plugin.tar .
+cd ..
 gzip che-service-plugin.tar
 


### PR DESCRIPTION
Moving of files is needed because spec of the plugin broker says that those files should be in the root of a tar.